### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 [![Coverage Status](https://coveralls.io/repos/certae/django-softmachine/badge.png?branch=master)](https://coveralls.io/r/certae/django-softmachine?branch=master)
 
-CeRTAE [SoftMachine](http://www.certae.org/index.php?id=88) proposes an approach based on DATARUN method. This approach consists in achieving the interfaces of an application by the contruction of views from a standard data model. In other words, you can prototype and export a new application model. 
+CeRTAE [SoftMachine](http://www.certae.org/index.php?id=88) proposes an approach based on DATARUN method. This approach consists in achieving the interfaces of an application by the construction of views from a standard data model. In other words, you can prototype and export a new application model. 
 The system architecture is a Web MVC variant, this means that we use the basic concepts of Model, View and Controller adapted to a Web App.
 
 >[GPL License V3](docs/LICENSE.md)


### PR DESCRIPTION
@certae, I've corrected a typographical error in the documentation of the [django-softmachine](https://github.com/certae/django-softmachine) project. Specifically, I've changed contruction to construction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
